### PR TITLE
feat: <code> support

### DIFF
--- a/lua/tests/docgen/renderer_spec.lua
+++ b/lua/tests/docgen/renderer_spec.lua
@@ -558,6 +558,41 @@ describe('renderer', function()
     end)
   end)
 
+  describe('code', function()
+    it('works with simple example', function()
+      eq('>\nHello World\n<', renderer.render({'<code>', 'Hello World', '</code>' }, '', 80))
+    end)
+
+    it('works with complex example', function()
+      eq('>\nSteps\n Hello\n  World\n<', renderer.render({'<code>', 'Steps', ' Hello', '  World', '</code>' }, '', 80))
+    end)
+
+    it('combination with Paragraph', function()
+      eq(dedent[[
+        This is a long paragraph that will be wrapped after that we expect a pre block
+        that will ignore stuff
+
+        >
+        Steps
+         Hello
+          World
+        <
+
+        End paragraph just for the LULW s. Please just work.]],
+        renderer.render({
+          'This is a long paragraph that will be wrapped after that we expect a pre block that will ignore stuff',
+          '',
+          '<code>',
+          'Steps',
+          ' Hello',
+          '  World',
+          '</code>',
+          '',
+          'End paragraph just for the LULW s. Please just work.',
+        }, '', 80))
+    end)
+  end)
+
   describe('pre with prefix', function()
     it('can ignore simple blocks', function()
       eq('    Hello World', renderer.render({'<pre>', 'Hello World', '</pre>' }, '    ', 80))


### PR DESCRIPTION
Closes #24 

Example
```lua
--- <code>
--- require('telescope').setup{
---   defaults = {
---     -- Default configuration for telescope goes here:
---     -- config_key = value,
---     -- ..
---   },
---   pickers = {
---     -- Default configuration for builtin pickers goes here:
---     -- picker_name = {
---     --   picker_config_key = value,
---     --   ...
---     -- }
---     -- Now the picker_config_key will be applied every time you call this
---     -- builtin picker
---   },
---   extensions = {
---     -- Your extension configuration goes here:
---     -- extension_name = {
---     --   extension_config_key = value,
---     -- }
---     -- please take a look at the readme of the extension you want to configure
---   }
--- }
--- </code>
```