### PR TITLE
Ensure that function name in annotation is read as Vim's help tag

### DIFF
--- a/lua/docgen/help.lua
+++ b/lua/docgen/help.lua
@@ -236,7 +236,8 @@ help.format_function_metadata = function(function_metadata, config)
     )
   )
 
-  local right_side = string.format("*%s()*", name)
+  -- Add single whitespace on the left to ensure that it reads as help tag
+  local right_side = string.format(" *%s()*", name)
 
   -- TODO(conni2461): LONG function names break this thing
   local header = align_text(left_side, right_side, 78)

--- a/lua/tests/docgen/function_spec.lua
+++ b/lua/tests/docgen/function_spec.lua
@@ -450,6 +450,32 @@ describe("functions", function()
       )
     end)
 
+    it("should create help tag in case of long function signature", function()
+      check_function_output(
+        [[
+        local x = {}
+
+        --- This function has documentation
+        ---@param very_long_parameter_1 number: Very long parameter 1.
+        ---@param very_long_parameter_2 number: Very long parameter 2.
+        ---@param very_long_parameter_3 number: Very long parameter 3.
+        function x.normal_function(very_long_parameter_1, very_long_parameter_2, very_long_parameter_3)
+          return true
+        end
+
+        return x]],
+        [[
+        x.normal_function({very_long_parameter_1}, {very_long_parameter_2}, {very_long_parameter_3}) *x.normal_function()*
+            This function has documentation
+
+
+            Parameters: ~
+                {very_long_parameter_1} (number)  Very long parameter 1.
+                {very_long_parameter_2} (number)  Very long parameter 2.
+                {very_long_parameter_3} (number)  Very long parameter 3.]]
+      )
+    end)
+
     it("should work with return", function()
       check_function_output(
         [[


### PR DESCRIPTION
This change deals with case when function name and its parameters are very long. This leads to left (full function name with all parameters) and right (Vim's help tag) parts to touch without any space. This leads to not recognized help tag.