### PR TITLE
Support multiple tags 

### DIFF
--- a/lua/docgen/help.lua
+++ b/lua/docgen/help.lua
@@ -39,7 +39,12 @@ help.format = function(metadata)
 
   add(string.rep("=", 80))
   if metadata.tag then
-    add(align_text(nil, string.format("*%s*", metadata.tag, "*"), 80))
+    -- Support multiple tags
+    local tags = vim.tbl_map(function(x)
+      return string.format("*%s*", x)
+    end, vim.split(metadata.tag, "%s+"))
+
+    add(align_text(nil, table.concat(tags, " "), 80))
     add()
   end
 


### PR DESCRIPTION
This change allows having multiple tags, like `---@tag your_module another_name`. It can be useful if there are more than one preferred ways to address to section.

I was set to add tests but couldn't decide what is the preferred place for them. I end up using `@tag` alongside `@brief`, but there are no current tests for tags there. So where can I put tests?