### PR TITLE
Make file enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,9 @@
-ts := "./node_modules/tree-sitter-cli/tree-sitter"
+ts := ./node_modules/tree-sitter-cli/tree-sitter
 
-ifeq (, ${ts})
-	ts := $(shell which tree-sitter 2> /dev/null)
-endif
+$(ts):
+	npm ci
 
-ifeq (, ${ts})
-	ts := $(shell which tree-sitter-cli 2> /dev/null)
-endif
-
-generate:
+generate: | $(ts)
 	${ts} generate
 
 test: generate

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,9 @@ test_docgen: generate
 		-c "PlenaryBustedDirectory lua/tests/ {minimal_init = 'tests/minimal_init.vim'}"
 
 build_parser: generate
-	mkdir -p build
+	mkdir -p build parser
 	cc -o ./build/parser.so -I./src src/parser.c src/scanner.cc -shared -Os -lstdc++ -fPIC
+	cp ./build/parser.so ./parser/lua.so
 
 gen_howto:
 	nvim --headless --noplugin -u tests/minimal_init.vim -c "luafile ./scratch/gen_howto.lua" -c 'qa'


### PR DESCRIPTION
### The Motivation
To make building the parser for generating documentation for `telescope.nvim` on a local machine a touch simpler. 

Currently there are some manual steps required to set up the `parser` directory before generating the parser and later copying/sym linking the `parser.so` to the `parser` directory.

This PR is trying to streamline that.

### The Changes

- make `node tree-sitter` a build dependency and install it if it's not installed yet
- create the `parser` directory if it does not exist yet
- after building the parser, copy the generated `parser.so` to the `parser/lua.so`

### Notes
I have removed the following lines from the `Makefile`
```
ifeq (, ${ts})
    ts := $(shell which tree-sitter 2> /dev/null)
endif

ifeq (, ${ts})
    ts := $(shell which tree-sitter-cli 2> /dev/null)
endif
```
as the above conditionals always evaluate to `false` because `${ts}` is never empty (it has been set to `"./node_modules/tree-sitter-cli/tree-sitter"` on line 1).

