### PR TITLE
fix: make build_parser compatible with macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build_parser: generate
 	mkdir -p build
 	cc -o ./build/parser.so -I./src src/parser.c src/scanner.c -shared -Os -fPIC
 	mkdir -p parser
-	cp -u ./build/parser.so ./parser/lua.so || exit 0
+	rsync -u ./build/parser.so ./parser/lua.so || exit 0
 
 gen_howto:
 	nvim --headless --noplugin -u tests/init.lua -c "luafile ./scratch/gen_howto.lua" -c 'qa'


### PR DESCRIPTION
It seems in macOS `cp -u` is not a thing, but `rsync -u` is.

<img width="869" alt="image" src="https://github.com/tjdevries/tree-sitter-lua/assets/4324982/836d5150-fd6a-4c30-83cf-4f338e34038e">
