### PR TITLE
Add `tree-sitter` section to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,13 @@
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.20.0"
-  }
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.lua",
+      "file-types": [
+        "lua"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Docs list scope as required, see: https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics

Additional context: with this grammar, `tree-sitter dump-languages` does not show a scope of `lua`
```
scope:
parser: "/Users/anon/Documents/Code/tree-sitter-grammars/grammars/tree-sitter-lua"
highlights: None
file_types: []
content_regex: None
injection_regex: None
```
The `tree-sitter highlight` command can use the `scope` to select which grammar to use for highlighting.